### PR TITLE
Remove polyfill.io script

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,4 @@
 
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
 
 </script>{% if site.footer_scripts %}


### PR DESCRIPTION
## Summary
- Remove the external polyfill.io script loader from the site template.
- Keep MathJax and existing footer/search scripts unchanged.

## Verification
- Confirmed no remaining polyfill.io references with rg.
- Ran git diff --check.
- Jekyll build was not run successfully because project gems are not installed for the repo Ruby.